### PR TITLE
Support overridding CM version, CDH version and cloudera mirror

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -8,3 +8,8 @@ computer_ou: ou=Hosts,ou=morhidi,ou=HadoopClusters,ou=morhidi,dc=ad,dc=sec,dc=cl
 domain: vpc.cloudera.com
 kdc: w2k8-1.ad.sec.cloudera.com
 admin_server: w2k8-1.ad.sec.cloudera.com
+
+cdh_version: 5.8.3
+scm_version: 5.8.3
+
+cloudera_mirror: https://archive.cloudera.com

--- a/group_vars/cdh_servers.yml
+++ b/group_vars/cdh_servers.yml
@@ -3,7 +3,6 @@
 db_hostname: "{{ hostvars[groups['db_server'][0]]['inventory_hostname'] }}"
 scm_hostname: "{{ hostvars[groups['scm_server'][0]]['inventory_hostname'] }}"
 
-cdh_version: 5.8.3
 cluster_display_name: cluster_1
 
 cdh_services:

--- a/group_vars/scm_server.yml
+++ b/group_vars/scm_server.yml
@@ -1,14 +1,12 @@
 ---
 
-scm_version: 5.8.3
 scm_port: 7180
 scm_default_user: admin
 scm_default_pass: admin
 
 scm_repositories:
-  - http://archive.cloudera.com/cdh5/parcels/5.8.3/
-  - https://archive.cloudera.com/cdh5/parcels/{latest_supported}/
+  - "{{ cloudera_mirror }}/cdh5/parcels/{{ cdh_version }}"
 
 scm_products:
   - product: CDH
-    version: 5.8.3-1.cdh5.8.3.p0.2
+    version: "{{ cdh_version }}-1.cdh{{ cdh_version }}.p0.2"

--- a/roles/cm_agents/tasks/main.yml
+++ b/roles/cm_agents/tasks/main.yml
@@ -5,8 +5,8 @@
 - name: Install Cloudera Manager Agents
   yum: name={{ item }} state=installed
   with_items:
-    - cloudera-manager-daemons
-    - cloudera-manager-agent
+    - cloudera-manager-daemons-{{ scm_version }}
+    - cloudera-manager-agent-{{ scm_version }}
 
 - name: Configure Cloudera Manager Agent 'server_host'
   lineinfile: dest=/etc/cloudera-scm-agent/config.ini regexp=^server_host line=server_host={{ hostvars[scm_hostname]['inventory_hostname'] }}

--- a/roles/cm_repo/tasks/main.yml
+++ b/roles/cm_repo/tasks/main.yml
@@ -4,8 +4,8 @@
   yum_repository:
     name: cloudera-manager
     description: Cloudera Manager
-    baseurl: http://archive.cloudera.com/cm5/redhat/{{ ansible_distribution_major_version }}/x86_64/cm/5/
-    gpgkey: http://archive.cloudera.com/cm5/redhat/{{ ansible_distribution_major_version }}/x86_64/cm/RPM-GPG-KEY-cloudera
+    baseurl: "{{ cloudera_mirror }}/cm5/redhat/{{ ansible_distribution_major_version }}/x86_64/cm/5/"
+    gpgkey: "{{ cloudera_mirror }}/cm5/redhat/{{ ansible_distribution_major_version }}/x86_64/cm/RPM-GPG-KEY-cloudera"
     gpgcheck: yes
     enabled: yes
   when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos")

--- a/roles/scm/tasks/main.yml
+++ b/roles/scm/tasks/main.yml
@@ -5,9 +5,9 @@
 - name: Install the Cloudera Manager Server Packages
   yum: name={{ item }} state=installed
   with_items:
-    - cloudera-manager-daemons
-    - cloudera-manager-server
-    - cloudera-manager-agent
+    - cloudera-manager-daemons-{{ scm_version }}
+    - cloudera-manager-server-{{ scm_version }}
+    - cloudera-manager-agent-{{ scm_version }}
 
 - name: Prepare Cloudera Manager Server External Database
   command: /usr/share/cmf/schema/scm_prepare_database.sh


### PR DESCRIPTION
This PR contains improvements from another fork, which will serve as the base to add CDH6/CM6 support to those Cloudera roles
TODO(me): fix the conflict